### PR TITLE
fix(msbuild) Add Native Microsoft builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ C Implementation of lzhuf compression used with Winlink
 * Adaptive Huffman Coding coded by Haruyasu YOSHIZAKI
 * Edited and translated to English by Kenji RIKITAKE
 
-## Building And Testing
+## Building And Testing Unix compatible
+
+On Microsoft Windows Msys2 Mingw64, use lzhuf.exe instead of lzhuf.
 
 ### Tools needed
 
@@ -18,7 +20,7 @@ C Implementation of lzhuf compression used with Winlink
 
 * diffutils
 
-#### Github contributing packages
+#### Packages for contributing to GitHub Pull Requests
 
 * bash file git grep shellcheck codespell yamllint
 
@@ -33,8 +35,6 @@ make
 
 ### Testing
 
-On Windows, use lzhuf.exe instead of lzhuf.
-
 ~~~text
 ./lzhuf e tests/test_data.ref test_data.lzh
 diff test_data.lzh tests/test_data.lzh_ref
@@ -43,15 +43,60 @@ diff test_data.src tests/test_data.ref
 
 ## Deployment in Linux style directory tree
 
-On Windows, use lzhuf.exe instead of lzhuf.
-
 ~~~text
 cp ./lzhuf /usr/local/bin/
 ~~~
 
-### GitHub Pull requests
+## Building on Microsoft Windows Native
 
-#### Git commit hook installation
+### Microsoft Windows Native Tools needed
+
+* Microsoft Visual Studio Community Edition or better
+
+### Microsoft Windows Building
+
+Need to launch a command prompt window.
+
+Set your directory to where the lzhuf source is checked out.
+
+MSbuild does not seem to run on PowerShell for Windows 7.
+
+You have to add the path to MSbuild using a script provided by Visual Studio.
+
+~~~bat
+"C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VSDevCmd.bat"
+~~~
+
+Then you can built the win32 and x64 release targets.
+
+~~~bat
+msbuild lzhuf.vcxproj -t:build -p:Configuration=Release -p:Platform=Win32
+msbuild lzhuf.vcxproj -t:build -p:Configuration=Release -p:Platform=x64
+~~~
+
+The Win32 build is put in the Release folder.
+
+The x64 build is put in the x64\Release folder.
+
+### Microsoft Windows Testing
+
+~~~bat
+W:\work\d-rats\lzhuf>Release\lzhuf e tests\test_data.ref test_data.lzh
+
+W:\work\d-rats\lzhuf>fc test_data.lzh tests/test_data.lzh_ref
+Comparing files test_data.lzh and TESTS/TEST_DATA.LZH_REF
+FC: no differences encountered
+
+W:\work\d-rats\lzhuf>x64\Release\lzhuf d test_data.lzh test_data.src
+
+W:\work\d-rats\lzhuf>fc test_data.src tests/test_data.ref
+Comparing files test_data.src and TESTS/TEST_DATA.REF
+FC: no differences encountered
+~~~
+
+## GitHub Pull requests
+
+### Git commit hook installation
 
 cp tests/pre-commit .git/hooks
 chmod 755 .git/hooks/pre-commit

--- a/lzhuf.c
+++ b/lzhuf.c
@@ -57,6 +57,16 @@
 
 #include "lzhuf.h"
 
+// Microsoft has deprecated fopen()
+#if (defined(_MSC_VER) && (_MSC_VER >= 1400) )
+static FILE* fopen_s_fix(char* fname, char* mode) {
+    FILE* fptr;
+    fopen_s(&fptr, fname, mode);
+    return fptr;
+}
+#define fopen(fname, mode) fopen_s_fix((fname), (mode))
+#endif
+
 #ifdef  B2F
 /* 24Mar2008, Maiko (VE4KLM), for reference to mbx structure */
 //#include "mailbox.h"
@@ -244,12 +254,6 @@ unsigned short crc16tab[256] = {
 #define UPDCRC16(cp, crc) (crc16tab[((crc >> 8) & 255)] ^ (crc << 8) ^ cp)
 
 #endif
-
-/* 23Apr2008, Maiko (VE4KLM), Added flag for b2f considerations */
-int Encode(int, char *, char *, struct lzhufstruct *, int);
-
-/* 24Mar2008, Maiko (VE4KLM), Added flag for b2f considerations */
-int Decode(int, char *, char *, struct lzhufstruct *, int);
 
 static int GetBit(struct lzhufstruct *);
 #ifdef MSDOS

--- a/lzhuf.h
+++ b/lzhuf.h
@@ -1,6 +1,11 @@
 #ifndef _LZHUF_H
 #define _LZHUF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #include <errno.h>
 #include <stdio.h>
 
@@ -94,6 +99,10 @@ int send_yapp(int, struct fwd *, char *, int);
 int recv_yapp(int, struct fwd *, char **, int32, int);
 int AllocDataBuffers(struct fwd *);
 void FreeDataBuffers(struct fwd *);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* defined(LZHUF) || defined(FBBCMP) */

--- a/lzhuf.sln
+++ b/lzhuf.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lzhuf", "lzhuf.vcxproj", "{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Debug|x64.ActiveCfg = Debug|x64
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Debug|x64.Build.0 = Debug|x64
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Debug|x86.ActiveCfg = Debug|Win32
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Debug|x86.Build.0 = Debug|Win32
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Release|x64.ActiveCfg = Release|x64
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Release|x64.Build.0 = Release|x64
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Release|x86.ActiveCfg = Release|Win32
+		{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {12A79DF2-1D42-4703-8877-DE8126822D85}
+	EndGlobalSection
+EndGlobal

--- a/lzhuf.vcxproj
+++ b/lzhuf.vcxproj
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+	<!--ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration-->
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+	<!--ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration-->
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{1E289C5A-CD1B-44B7-A8A5-EE91EBE5C047}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <!--PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup-->
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;LZHUF;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;LZHUF;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<ClCompile>
+			<PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;LZHUF;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+		</ClCompile>
+		<Link>
+			<TargetMachine>MachineX64</TargetMachine>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<OptimizeReferences>true</OptimizeReferences>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+	<ClCompile Include="lzhuf.c" />
+	<ClCompile Include="main.c" />
+  </ItemGroup>
+  <ItemGroup>
+	<ClInclude Include="lzhuf.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/lzhuf.vcxproj.filters
+++ b/lzhuf.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/lzhuf.vcxproj.user
+++ b/lzhuf.vcxproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ShowAllFiles>true</ShowAllFiles>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Add the ability to build lzhuf binaries with current Microsoft Visual Studio MSbuild program.

README.md:
  Updated for Microsoft Builds

lzhuf.c:
lzhuf.h:
  Fixes to be built with Microsoft Visual C++

lzhuf.sln:
lzhuf.vcxproj*:
  Files needed for MSbuild to make a simple project.